### PR TITLE
Bridge layout for future extensibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Each entry has the following format (subject to change):
      },
      {
         "type": "js",
-        "key": "tonkeeper", // window.tonkeeper
+        "key": "tonkeeper",
      }
   ],
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Each entry has the following format (subject to change):
   "tondns":  "tonkeeper.ton",
   "about_url": "https://tonkeeper.com",
   "universal_url": "https://app.tonkeeper.com/ton-connect",
-  "url_scheme": "tonkeeper",
   "bridge": [ 
      {
         "type": "sse",

--- a/README.md
+++ b/README.md
@@ -15,12 +15,17 @@ Each entry has the following format (subject to change):
   "tondns":  "tonkeeper.ton",
   "about_url": "https://tonkeeper.com",
   "universal_url": "https://app.tonkeeper.com/ton-connect",
-  "bridge": { 
-      "sse_url": "https://bridge.tonapi.io/bridge",
-  },
-  "js_bridge": { 
-      "key": "tonkeeper",
-  }
+  "url_scheme": "tonkeeper",
+  "bridge": [ 
+     {
+        "type": "sse",
+        "url": "https://bridge.tonapi.io/bridge",
+     },
+     {
+        "type": "js",
+        "key": "tonkeeper", // window.tonkeeper
+     }
+  ],
 }
 ```
 
@@ -30,12 +35,14 @@ Each entry has the following format (subject to change):
 - `tondns`: (optional) will be used in the protocol later.
 - `about_url`: info or landing page of your wallet. May be useful for TON newcomers.
 - `universal_url`: (optional) base part of your wallet universal url. Your link should support [Ton Connect parameters](https://github.com/ton-connect/docs/blob/main/bridge.md#universal-link)
-- `bridge.sse_url`: (optional) url of your wallet's implementation of the [HTTP bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#http-bridge).
-- `js_bridge.key`: (optional) if your wallet handles [JS Bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#js-bridge) connection, specify the binding for your bridge object accessible through `window`. Example: the key `"tonkeeper"` means the bridge can be accessed as `window.tonkeeper`.
+- `url_scheme`: (optional) custom URL scheme to direct user to the wallet app on the same device (without resolving through browser)
+- `bridge`: options for connectivity between the app and the wallet
+    - `type="sse"`: specify the `url` of your wallet's implementation of the [HTTP bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#http-bridge).
+    - `type="jsapi"`: specify the `key` through which your wallet handles [JS Bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#js-bridge) connection, specify the binding for your bridge object accessible through `window`. Example: the key `"tonkeeper"` means the bridge can be accessed as `window.tonkeeper`.
 
-If your wallet supports HTTP Bridge, you should specify `universal_url` and `bridge_url`. 
-If your wallet provides the JS bridge (e.g. as a browser extension), you should specify the `js_bridge_key`.
-If your wallet supports both bridges, you have to specify `universal_url`, `bridge_url` and `js_bridge_key`.
+If your wallet supports HTTP Bridge, you should specify `universal_url` and `bridge.type="sse"`. 
+If your wallet provides the JS bridge (e.g. as a browser extension), you should specify the `bridge.type="js"`.
+If your wallet supports both bridges, you have to specify `universal_url` and both `bridge.type="sse"` and `bridge.type="js"`.
 
 ### How do I add my wallet?
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Each entry has the following format (subject to change):
   "bridge": [ 
      {
         "type": "sse",
-        "url": "https://bridge.tonapi.io/bridge",
+        "url": "https://bridge.tonapi.io/bridge"
      },
      {
         "type": "js",
-        "key": "tonkeeper",
+        "key": "tonkeeper"
      }
   ],
 }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ Each entry has the following format (subject to change):
   "tondns":  "tonkeeper.ton",
   "about_url": "https://tonkeeper.com",
   "universal_url": "https://app.tonkeeper.com/ton-connect",
-  "bridge_url": "https://bridge.tonapi.io/bridge",
-  "js_bridge_key": "tonkeeper"
+  "bridge": { 
+      "sse_url": "https://bridge.tonapi.io/bridge",
+  },
+  "js_bridge": { 
+      "key": "tonkeeper",
+  }
 }
 ```
 
@@ -26,8 +30,8 @@ Each entry has the following format (subject to change):
 - `tondns`: (optional) will be used in the protocol later.
 - `about_url`: info or landing page of your wallet. May be useful for TON newcomers.
 - `universal_url`: (optional) base part of your wallet universal url. Your link should support [Ton Connect parameters](https://github.com/ton-connect/docs/blob/main/bridge.md#universal-link)
-- `bridge_url`: (optional) url of your wallet's implementation of the [HTTP bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#http-bridge).
-- `js_bridge_key`: (optional) if your wallet handles [JS Bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#js-bridge) connection, specify the binding for your bridge object accessible through `window`. Example: the key `"tonkeeper"` means the bridge can be accessed as `window.tonkeeper`.
+- `bridge.sse_url`: (optional) url of your wallet's implementation of the [HTTP bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#http-bridge).
+- `js_bridge.key`: (optional) if your wallet handles [JS Bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#js-bridge) connection, specify the binding for your bridge object accessible through `window`. Example: the key `"tonkeeper"` means the bridge can be accessed as `window.tonkeeper`.
 
 If your wallet supports HTTP Bridge, you should specify `universal_url` and `bridge_url`. 
 If your wallet provides the JS bridge (e.g. as a browser extension), you should specify the `js_bridge_key`.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Each entry has the following format (subject to change):
 - `url_scheme`: (optional) custom URL scheme to direct user to the wallet app on the same device (without resolving through browser)
 - `bridge`: options for connectivity between the app and the wallet
     - `type="sse"`: specify the `url` of your wallet's implementation of the [HTTP bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#http-bridge).
-    - `type="jsapi"`: specify the `key` through which your wallet handles [JS Bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#js-bridge) connection, specify the binding for your bridge object accessible through `window`. Example: the key `"tonkeeper"` means the bridge can be accessed as `window.tonkeeper`.
+    - `type="js"`: specify the `key` through which your wallet handles [JS Bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#js-bridge) connection, specify the binding for your bridge object accessible through `window`. Example: the key `"tonkeeper"` means the bridge can be accessed as `window.tonkeeper`.
 
 If your wallet supports HTTP Bridge, you should specify `universal_url` and `bridge.type="sse"`. 
 If your wallet provides the JS bridge (e.g. as a browser extension), you should specify the `bridge.type="js"`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Each entry has the following format (subject to change):
 - `tondns`: (optional) will be used in the protocol later.
 - `about_url`: info or landing page of your wallet. May be useful for TON newcomers.
 - `universal_url`: (optional) base part of your wallet universal url. Your link should support [Ton Connect parameters](https://github.com/ton-connect/docs/blob/main/bridge.md#universal-link)
-- `url_scheme`: (optional) custom URL scheme to direct user to the wallet app on the same device (without resolving through browser)
 - `bridge`: options for connectivity between the app and the wallet
     - `type="sse"`: specify the `url` of your wallet's implementation of the [HTTP bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#http-bridge).
     - `type="js"`: specify the `key` through which your wallet handles [JS Bridge](https://github.com/ton-connect/docs/blob/main/bridge.md#js-bridge) connection, specify the binding for your bridge object accessible through `window`. Example: the key `"tonkeeper"` means the bridge can be accessed as `window.tonkeeper`.

--- a/wallets.json
+++ b/wallets.json
@@ -5,7 +5,15 @@
     "tondns": "tonkeeper.ton",
     "about_url": "https://tonkeeper.com",
     "universal_url": "https://app.tonkeeper.com/ton-connect",
-    "bridge_url": "https://bridge.tonapi.io/bridge",
-    "js_bridge_key": "tonkeeper"
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://bridge.tonapi.io/bridge"
+      },
+      {
+        "type": "js",
+        "key": "tonkeeper"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
1. We add `url_scheme` field for the wallet app so it can be opened without going through the browser.
2. Restructure bridge info as a list of "bridge options" that can be extended in the future with websockets, variants of the protocol etc.