### PR TITLE
TonSafe now supports Ton Connect 2.0 protocol.

### DIFF
--- a/wallets.json
+++ b/wallets.json
@@ -17,18 +17,6 @@
     ]
   },
   {
-    "name": "TonSafe",
-    "image": "https://app.tonsafe.net/images/tonsafe-prime-300x300.png",
-    "about_url": "https://tonsafe.net/about",
-    "universal_url": "https://app.tonsafe.net/ton-connect",
-    "bridge": [
-      {
-        "type": "sse",
-        "url": "https://bridge.tonapi.io/bridge"
-      }
-    ]
-  },
-  {
     "name": "OpenMask",
     "image": "https://raw.githubusercontent.com/OpenProduct/openmask-extension/main/public/openmask-logo-288.png",
     "about_url": "https://www.openmask.app/",
@@ -47,6 +35,18 @@
       {
         "type": "js",
         "key": "mytonwallet"
+      }
+    ]
+  },
+  {
+    "name": "TonSafe",
+    "image": "https://app.tonsafe.net/images/tonsafe-prime-300x300.png",
+    "about_url": "https://tonsafe.net/about",
+    "universal_url": "https://app.tonsafe.net/ton-connect",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://bridge.tonapi.io/bridge"
       }
     ]
   }

--- a/wallets.json
+++ b/wallets.json
@@ -17,6 +17,22 @@
     ]
   },
   {
+    "name": "TonSafe",
+    "image": "https://app.tonsafe.net/images/tonsafe-prime-300x300.png",
+    "about_url": "https://tonsafe.net/about",
+    "universal_url": "https://app.tonsafe.net/ton-connect",
+    "bridge": [
+      {
+        "type": "sse",
+        "url": "https://bridge.tonapi.io/bridge"
+      },
+      {
+        "type": "js",
+        "key": "tonsafe"
+      }
+    ]
+  },
+  {
     "name": "OpenMask",
     "image": "https://raw.githubusercontent.com/OpenProduct/openmask-extension/main/public/openmask-logo-288.png",
     "about_url": "https://www.openmask.app/",

--- a/wallets.json
+++ b/wallets.json
@@ -25,10 +25,6 @@
       {
         "type": "sse",
         "url": "https://bridge.tonapi.io/bridge"
-      },
-      {
-        "type": "js",
-        "key": "tonsafe"
       }
     ]
   },


### PR DESCRIPTION
# Add TonSafe wallet

## Supports
- [] JS bridge as a browser extention for [Google Chrome](<chrome store url>), ..., browsers.
- [ ] JS bridge for the in-wallet browser for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [x] HTTP bridge as a mobile wallet app for [iOS](https://apps.apple.com/us/app/tonsafe-ton-wallet/id1636826473) and [Android](https://play.google.com/store/apps/details?id=com.tonsafe.wallet).
- [ ] HTTP bridge as a desktop wallet app for [Windows](<link>), [macOS](<link>), ... .

Ton Connect 2.0 is supported on TonSafe versions >= 2.2

## Supported features
- [ ] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)


## Tests
[a demo dapp with integrated wallet](https://raw.githubusercontent.com/tonsafe/wallets-list/main/Tonsafe-Tonconnect-Demo.m4v)

## Integrator contacts
* [telegram] [https://t.me/tonsafesupportbot]
* [email] ops@tonsafe.org
