### PR TITLE
bron: add ios and android platforms

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -893,7 +893,7 @@
       "url": "https://connect.ton.org/bridge"
     }
   ],
-  "platforms": ["windows", "macos"],
+  "platforms": ["ios", "android", "windows", "macos"],
   "features": [
     {
       "name": "SendTransaction",


### PR DESCRIPTION
# Add mobile platform for the Bron wallet

## Supports
- [ ] JS bridge as a browser extention for [Google Chrome](<chrome store url>), ..., browsers.
- [] JS bridge for the in-wallet browser for [iOS](<link>) and [Android](<link>).
- [] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [x] HTTP bridge as a mobile wallet app for [iOS](https://apps.apple.com/us/app/bron-wallet/id6757437880) and [Android](https://play.google.com/store/apps/details?id=org.bron.mobile).
- [x] HTTP bridge as a desctop wallet app for [Windows](https://app.bron.org/), [macOS](https://app.bron.org/), ... .

## Supported features
- [x] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)
- [x] SignData (`text`, `binary`, `cell`)


## Tests

## Integrator contacts
* telegram [@horus20](https://t.me/horus20)

Desktop builds (win/macOS) are available from the web app at `app.bron.org` — links rotate per release.