### PR TITLE
Track 78b12da (remove abandoned wallets)

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -3,4 +3,4 @@
 # pointer also publishes its own image — no separate re-tag step is needed.
 release:
   branch: main
-  sha: a45d17f
+  sha: 78b12da


### PR DESCRIPTION
Release pointer moves from a45d17f to 78b12da.

Picks up #308 (dewallet and nicegramWallet removed from the list - both projects are abandoned and their bridge domains no longer resolve).