### PR TITLE
Track dc2d455 (add GiftPass Wallet)

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -3,4 +3,4 @@
 # pointer also publishes its own image — no separate re-tag step is needed.
 release:
   branch: main
-  sha: 78b12da
+  sha: dc2d455


### PR DESCRIPTION
Release pointer moves from 78b12da to dc2d455.

Picks up #313 (GiftPass Wallet added to the list - Chrome extension, JS bridge only).
