### PR TITLE
Add GramVault wallet

### DIFF
--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -911,6 +911,11 @@
   "bridge": [
     { "type": "sse", "url": "https://bridge.tonapi.io/bridge" }
   ],
-  "platforms": ["android", "ios"]
+  "platforms": ["android", "ios"],
+  "features": [
+    { "name": "SendTransaction", "maxMessages": 4, "extraCurrencySupported":
+  false },
+    { "name": "SignData", "types": ["text", "binary", "cell"] }
+  ]
 }
 ]

--- a/wallets-v2.json
+++ b/wallets-v2.json
@@ -900,5 +900,17 @@
         "extraCurrencySupported": false
       }
     ]
-  }
+  },
+  {
+  "app_name": "gramvault",
+  "name": "GramVault",
+  "image": "https://dcoos.com/gram/tonconnect/icon-288.png",
+  "about_url": "https://dcoos.com/gram/tonconnect",
+  "universal_url": "https://dcoos.com/gram/tonconnect",
+  "deepLink": "gramvault://ton-connect",
+  "bridge": [
+    { "type": "sse", "url": "https://bridge.tonapi.io/bridge" }
+  ],
+  "platforms": ["android", "ios"]
+}
 ]


### PR DESCRIPTION
GramVault — self-custody TON wallet for Android and iOS. Universal link: https://dcoos.com/gram/tonconnect
HTTP (SSE) bridge: https://bridge.tonapi.io/bridge

# Add <WALLET_NAME> wallet

## Supports
- [x] JS bridge as a browser extention for [Google Chrome](<chrome store url>), ..., browsers.
- [ ] JS bridge for the in-wallet browser for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] JS bridge for in-wallet browser for [Windows](<link>), [macOS](<link>), ... .
- [x] HTTP bridge as a mobile wallet app for [iOS](<appstore link>) and [Android](<google play link>).
- [ ] HTTP bridge as a desctop wallet app for [Windows](<link>), [macOS](<link>), ... .

## Supported features
- [ ] [ton_proof](https://github.com/ton-connect/docs/blob/main/requests-responses.md#address-proof-signature-ton_proof)
- [x] [SendTransaction](https://github.com/ton-connect/docs/blob/main/requests-responses.md#methods)


## Tests
[a demo dapp with integrated wallet](link)

## Integrator contacts
* telegram
* email
* discord
* ...
