### PR TITLE
Track aa1ebbc (add DeWallet)

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -3,4 +3,4 @@
 # pointer also publishes its own image — no separate re-tag step is needed.
 release:
   branch: main
-  sha: f7ec7cf
+  sha: aa1ebbc


### PR DESCRIPTION
Release pointer moves from f7ec7cf to aa1ebbc.

Picks up #320 (add DeWallet, rebased/reassembled from #312).
